### PR TITLE
Fix Github pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Pages
 on:
   push:
     branches:
-      - '**'
+      - main
 
 jobs:
   github-pages:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Pages
 on:
   push:
     branches:
-      - main
+      - '**'
 
 jobs:
   github-pages:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 14.x
 
       - name: Install
-        run: npm install
+        run: npm run install:pages
 
       - name: Build Pages
         run: npm run build:pages

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "publish:unstable": "lerna publish prerelease --preid unstable --yes",
     "release": "lerna publish",
     "release:canary": "lerna publish --canary",
+    "install:pages": "lerna bootstrap --scope smoke-test-react --include-dependencies",
     "build:pages": "rm -rf ./docs/smoke-test-react && lerna run build:smoke-test-react"
   },
   "devDependencies": {

--- a/packages/smoke-test-react/package.json
+++ b/packages/smoke-test-react/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^12.8.1",
     "@transmute/did-key-ed25519": "^0.2.1-unstable.37",
     "@transmute/ed25519-signature-2018": "^0.6.1-unstable.17",
+    "@transmute/universal-wallet": "^0.6.1-unstable.17",
     "@transmute/universal-wallet-did-key-plugin": "^0.6.1-unstable.17",
     "@transmute/universal-wallet-did-web-plugin": "^0.6.1-unstable.17",
     "@transmute/universal-wallet-edv-plugin": "^0.6.1-unstable.17",

--- a/packages/web-crypto-key-pair/package.json
+++ b/packages/web-crypto-key-pair/package.json
@@ -3,7 +3,6 @@
   "author": "Orie Steele",
   "module": "dist/web-crypto-key-pair.esm.js",
   "version": "0.6.1-unstable.17",
-  "private": true,
   "license": "Apache-2.0",
   "homepage": "https://github.com/transmute-industries/verifiable-data/tree/main/packages/web-crypto-key-pair",
   "repository": {


### PR DESCRIPTION
- Fix Github pages deploy (it's failing on main currently)
- Make the `web-crypto-key-pair` public so that it gets published to npm