### PR TITLE
Confirming compression test vectors for did-key

### DIFF
--- a/packages/web-crypto-key-pair/package-lock.json
+++ b/packages/web-crypto-key-pair/package-lock.json
@@ -2412,8 +2412,7 @@
 		"big-integer": {
 			"version": "1.6.48",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-			"dev": true
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
 		},
 		"big.js": {
 			"version": "5.2.2",

--- a/packages/web-crypto-key-pair/package-lock.json
+++ b/packages/web-crypto-key-pair/package-lock.json
@@ -2409,6 +2409,12 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+			"dev": true
+		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",

--- a/packages/web-crypto-key-pair/package.json
+++ b/packages/web-crypto-key-pair/package.json
@@ -57,6 +57,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@peculiar/webcrypto": "^1.1.6"
+    "@peculiar/webcrypto": "^1.1.6",
+    "big-integer": "^1.6.48"
   }
 }

--- a/packages/web-crypto-key-pair/package.json
+++ b/packages/web-crypto-key-pair/package.json
@@ -49,6 +49,7 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.9.2",
+    "elliptic": "^6.5.4",
     "jose": "^2.0.3",
     "size-limit": "^4.9.2",
     "ts-jest": "^26.5.0",

--- a/packages/web-crypto-key-pair/src/__tests__/compression.test.ts
+++ b/packages/web-crypto-key-pair/src/__tests__/compression.test.ts
@@ -1,0 +1,88 @@
+import { base58 } from '../encoding';
+import { compress, expand } from '../compression/ec-compression';
+
+it('P-384 compress / expand public key', () => {
+  const oldForm = {
+    id:
+      '#zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU',
+    type: 'JsonWebKey2020',
+    controller:
+      'did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU',
+    publicKeyJwk: {
+      kty: 'EC',
+      crv: 'P-384',
+      x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
+      y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
+    },
+  };
+
+  const newForm = {
+    id:
+      '#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+    type: 'JsonWebKey2020',
+    controller:
+      'did:key:did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+    publicKeyJwk: {
+      kty: 'EC',
+      crv: 'P-384',
+      x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
+      y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
+    },
+  };
+  const publicKey = Buffer.concat([
+    Buffer.from(oldForm.publicKeyJwk.x, 'base64'),
+    Buffer.from(oldForm.publicKeyJwk.y, 'base64'),
+  ]);
+  const compressed = compress(publicKey);
+  const compressedFingerprint = base58.encode(
+    Buffer.concat([Buffer.from('8124', 'hex'), compressed])
+  );
+  expect('#z' + compressedFingerprint).toBe(newForm.id);
+  const decompressed = expand(compressed, oldForm.publicKeyJwk.crv);
+  const uncompressedFingerprint = base58.encode(
+    Buffer.concat([Buffer.from('8124', 'hex'), decompressed])
+  );
+  expect('#z' + uncompressedFingerprint).toBe(oldForm.id);
+});
+
+it('P-256 compress / expand public key', () => {
+  const oldForm = {
+    id:
+      '#zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve',
+    type: 'JsonWebKey2020',
+    controller:
+      'did:key:zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve',
+    publicKeyJwk: {
+      kty: 'EC',
+      crv: 'P-256',
+      x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
+      y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
+    },
+  };
+
+  const newForm = {
+    id: '#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+    type: 'JsonWebKey2020',
+    controller: 'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+    publicKeyJwk: {
+      kty: 'EC',
+      crv: 'P-256',
+      x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
+      y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
+    },
+  };
+  const publicKey = Buffer.concat([
+    Buffer.from(oldForm.publicKeyJwk.x, 'base64'),
+    Buffer.from(oldForm.publicKeyJwk.y, 'base64'),
+  ]);
+  const compressed = compress(publicKey);
+  const compressedFingerprint = base58.encode(
+    Buffer.concat([Buffer.from('8024', 'hex'), compressed])
+  );
+  expect('#z' + compressedFingerprint).toBe(newForm.id);
+  const decompressed = expand(compressed, oldForm.publicKeyJwk.crv);
+  const uncompressedFingerprint = base58.encode(
+    Buffer.concat([Buffer.from('8024', 'hex'), decompressed])
+  );
+  expect('#z' + uncompressedFingerprint).toBe(oldForm.id);
+});

--- a/packages/web-crypto-key-pair/src/__tests__/compression.test.ts
+++ b/packages/web-crypto-key-pair/src/__tests__/compression.test.ts
@@ -1,19 +1,62 @@
 import { base58 } from '../encoding';
 import { compress, expand } from '../compression/ec-compression';
 
+it('P-521 compress / expand public key', () => {
+  const publicKeyJwk = {
+    kty: 'EC',
+    crv: 'P-521',
+    x:
+      'AQgyFy6EwH3_u_KXPw8aTXTY7WSVytmbuJeFpq4U6LipxtSmBJe_jjRzms9qubnwm_fGoHMQlvQ1vzS2YLusR2V0',
+    y:
+      'Ab06MCcgoG7dM2I-VppdLV1k3lDoeHMvyYqHVfP05Ep2O7Zu0Qwd6IVzfZi9K0KMDud22wdnGUpUtFukZo0EeO15',
+  };
+  const oldForm = {
+    id:
+      '#zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S',
+    type: 'JsonWebKey2020',
+    controller:
+      'did:key:zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S',
+    publicKeyJwk,
+  };
+
+  const newForm = {
+    id:
+      '#z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+    type: 'JsonWebKey2020',
+    controller:
+      'did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+    publicKeyJwk,
+  };
+  const publicKey = Buffer.concat([
+    Buffer.from(oldForm.publicKeyJwk.x, 'base64'),
+    Buffer.from(oldForm.publicKeyJwk.y, 'base64'),
+  ]);
+  const compressed = compress(publicKey);
+  const compressedFingerprint = base58.encode(
+    Buffer.concat([Buffer.from('8224', 'hex'), compressed])
+  );
+  expect('#z' + compressedFingerprint).toBe(newForm.id);
+  const decompressed = expand(compressed, oldForm.publicKeyJwk.crv);
+  const uncompressedFingerprint = base58.encode(
+    Buffer.concat([Buffer.from('8224', 'hex'), decompressed])
+  );
+  expect('#z' + uncompressedFingerprint).toBe(oldForm.id);
+});
+
 it('P-384 compress / expand public key', () => {
+  const publicKeyJwk = {
+    kty: 'EC',
+    crv: 'P-384',
+    x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
+    y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
+  };
   const oldForm = {
     id:
       '#zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU',
     type: 'JsonWebKey2020',
     controller:
       'did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU',
-    publicKeyJwk: {
-      kty: 'EC',
-      crv: 'P-384',
-      x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
-      y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
-    },
+    publicKeyJwk,
   };
 
   const newForm = {
@@ -21,13 +64,8 @@ it('P-384 compress / expand public key', () => {
       '#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
     type: 'JsonWebKey2020',
     controller:
-      'did:key:did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
-    publicKeyJwk: {
-      kty: 'EC',
-      crv: 'P-384',
-      x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
-      y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
-    },
+      'did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+    publicKeyJwk,
   };
   const publicKey = Buffer.concat([
     Buffer.from(oldForm.publicKeyJwk.x, 'base64'),
@@ -46,30 +84,27 @@ it('P-384 compress / expand public key', () => {
 });
 
 it('P-256 compress / expand public key', () => {
+  const publicKeyJwk = {
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
+    y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
+  };
+
   const oldForm = {
     id:
       '#zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve',
     type: 'JsonWebKey2020',
     controller:
       'did:key:zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve',
-    publicKeyJwk: {
-      kty: 'EC',
-      crv: 'P-256',
-      x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
-      y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
-    },
+    publicKeyJwk,
   };
 
   const newForm = {
     id: '#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
     type: 'JsonWebKey2020',
     controller: 'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
-    publicKeyJwk: {
-      kty: 'EC',
-      crv: 'P-256',
-      x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
-      y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
-    },
+    publicKeyJwk,
   };
   const publicKey = Buffer.concat([
     Buffer.from(oldForm.publicKeyJwk.x, 'base64'),

--- a/packages/web-crypto-key-pair/src/__tests__/elliptic.sanity.test.ts
+++ b/packages/web-crypto-key-pair/src/__tests__/elliptic.sanity.test.ts
@@ -1,0 +1,218 @@
+import { base58 } from '../encoding';
+const EC = require('elliptic').ec;
+
+describe('P-521', () => {
+  const ec = new EC('p521');
+  const publicKeyJwk = {
+    kty: 'EC',
+    crv: 'P-521',
+    x:
+      'AQgyFy6EwH3_u_KXPw8aTXTY7WSVytmbuJeFpq4U6LipxtSmBJe_jjRzms9qubnwm_fGoHMQlvQ1vzS2YLusR2V0',
+    y:
+      'Ab06MCcgoG7dM2I-VppdLV1k3lDoeHMvyYqHVfP05Ep2O7Zu0Qwd6IVzfZi9K0KMDud22wdnGUpUtFukZo0EeO15',
+  };
+
+  it('compressed', () => {
+    const compressed = ec
+      .keyFromPublic(
+        '04' +
+          Buffer.concat([
+            Buffer.from(publicKeyJwk.x, 'base64'),
+            Buffer.from(publicKeyJwk.y, 'base64'),
+          ]).toString('hex'),
+        'hex'
+      )
+      .getPublic(true, 'hex');
+
+    const compressedFingerprint = base58.encode(
+      Buffer.concat([
+        Buffer.from('8224', 'hex'),
+        Buffer.from(compressed, 'hex'),
+      ])
+    );
+
+    const newForm = {
+      id:
+        '#z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+      publicKeyJwk,
+    };
+
+    expect('#z' + compressedFingerprint).toBe(newForm.id);
+  });
+
+  it('expanded', () => {
+    const expanded = ec
+      .keyFromPublic(
+        '04' +
+          Buffer.concat([
+            Buffer.from(publicKeyJwk.x, 'base64'),
+            Buffer.from(publicKeyJwk.y, 'base64'),
+          ]).toString('hex'),
+        'hex'
+      )
+      .getPublic(false, 'hex');
+
+    const expandedFingerprint = base58.encode(
+      Buffer.concat([
+        Buffer.from('8224', 'hex'),
+        Buffer.from(expanded.substring(2), 'hex'),
+      ])
+    );
+
+    const oldForm = {
+      id:
+        '#zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S',
+      publicKeyJwk,
+    };
+
+    expect('#z' + expandedFingerprint).toBe(oldForm.id);
+  });
+});
+
+describe('P-384', () => {
+  const ec = new EC('p384');
+  const publicKeyJwk = {
+    kty: 'EC',
+    crv: 'P-384',
+    x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
+    y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
+  };
+
+  it('compressed', () => {
+    const compressed = ec
+      .keyFromPublic(
+        '04' +
+          Buffer.concat([
+            Buffer.from(publicKeyJwk.x, 'base64'),
+            Buffer.from(publicKeyJwk.y, 'base64'),
+          ]).toString('hex'),
+        'hex'
+      )
+      .getPublic(true, 'hex');
+
+    const compressedFingerprint = base58.encode(
+      Buffer.concat([
+        Buffer.from('8124', 'hex'),
+        Buffer.from(compressed, 'hex'),
+      ])
+    );
+
+    const newForm = {
+      id:
+        '#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+      publicKeyJwk,
+    };
+
+    expect('#z' + compressedFingerprint).toBe(newForm.id);
+  });
+
+  it('expanded', () => {
+    const expanded = ec
+      .keyFromPublic(
+        '04' +
+          Buffer.concat([
+            Buffer.from(publicKeyJwk.x, 'base64'),
+            Buffer.from(publicKeyJwk.y, 'base64'),
+          ]).toString('hex'),
+        'hex'
+      )
+      .getPublic(false, 'hex');
+
+    const expandedFingerprint = base58.encode(
+      Buffer.concat([
+        Buffer.from('8124', 'hex'),
+        Buffer.from(expanded.substring(2), 'hex'),
+      ])
+    );
+
+    const oldForm = {
+      id:
+        '#zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU',
+      publicKeyJwk,
+    };
+
+    expect('#z' + expandedFingerprint).toBe(oldForm.id);
+  });
+});
+
+describe('P-256', () => {
+  const ec = new EC('p256');
+  const publicKeyJwk = {
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
+    y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
+  };
+
+  it('compressed', () => {
+    const compressed = ec
+      .keyFromPublic(
+        '04' +
+          Buffer.concat([
+            Buffer.from(publicKeyJwk.x, 'base64'),
+            Buffer.from(publicKeyJwk.y, 'base64'),
+          ]).toString('hex'),
+        'hex'
+      )
+      .getPublic(true, 'hex');
+
+    const compressedFingerprint = base58.encode(
+      Buffer.concat([
+        Buffer.from('8024', 'hex'),
+        Buffer.from(compressed, 'hex'),
+      ])
+    );
+
+    const newForm = {
+      id: '#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+      type: 'JsonWebKey2020',
+      controller: 'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+      publicKeyJwk,
+    };
+
+    expect('#z' + compressedFingerprint).toBe(newForm.id);
+  });
+
+  it('expanded', () => {
+    const expanded = ec
+      .keyFromPublic(
+        '04' +
+          Buffer.concat([
+            Buffer.from(publicKeyJwk.x, 'base64'),
+            Buffer.from(publicKeyJwk.y, 'base64'),
+          ]).toString('hex'),
+        'hex'
+      )
+      .getPublic(false, 'hex');
+
+    const expandedFingerprint = base58.encode(
+      Buffer.concat([
+        Buffer.from('8024', 'hex'),
+        Buffer.from(expanded.substring(2), 'hex'),
+      ])
+    );
+
+    const oldForm = {
+      id:
+        '#zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve',
+      publicKeyJwk,
+    };
+
+    expect('#z' + expandedFingerprint).toBe(oldForm.id);
+  });
+});

--- a/packages/web-crypto-key-pair/src/__tests__/exportAs.test.ts
+++ b/packages/web-crypto-key-pair/src/__tests__/exportAs.test.ts
@@ -1,0 +1,48 @@
+import { KeyPair } from '../KeyPair';
+// https://ns.did.ai/suites/multikey-2021/
+describe('can export as multikey', () => {
+  it('P-521', async () => {
+    const fingerprint =
+      'z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f';
+    const k = await KeyPair.fromFingerprint({ fingerprint });
+    const k1 = await k.export({ type: 'P521Key2021' });
+    expect(k1).toEqual({
+      id:
+        'did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f#z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+      type: 'P521Key2021',
+      controller:
+        'did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+      publicKeyBase58:
+        '6AYA5PnWHzdwRCM22E2yDvRctNQ6SmgttyLCDAFeTNnzPbaUXW5c7uk139fn2HTA4bYMJrpEmBnJq2dLCiCoB7XJRi3',
+    });
+  });
+
+  it('P-384', async () => {
+    const fingerprint =
+      'z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9';
+    const k = await KeyPair.fromFingerprint({ fingerprint });
+    const k1 = await k.export({ type: 'P384Key2021' });
+    expect(k1).toEqual({
+      id:
+        'did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+      type: 'P384Key2021',
+      controller:
+        'did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+      publicKeyBase58:
+        'ad1jjx1hRrEkMWSsFsXpLULAbmUq67ii1jRsBNtYEKhCwLXTo4wcjY7C2K4cuGZ859',
+    });
+  });
+
+  it('P-256', async () => {
+    const fingerprint = 'zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv';
+    const k = await KeyPair.fromFingerprint({ fingerprint });
+    const k1 = await k.export({ type: 'P256Key2021' });
+    expect(k1).toEqual({
+      id:
+        'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+      type: 'P256Key2021',
+      controller: 'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+      publicKeyBase58: '23youFZZdHMVdpv28DRSWP2zJbTJ8KHBeSKUX3qVqqnmp',
+    });
+  });
+});

--- a/packages/web-crypto-key-pair/src/__tests__/fromFingerprint.test.ts
+++ b/packages/web-crypto-key-pair/src/__tests__/fromFingerprint.test.ts
@@ -1,0 +1,62 @@
+import { KeyPair } from '../KeyPair';
+describe('can get public key from compressed fingerprint', () => {
+  it('P-521', async () => {
+    const fingerprint =
+      'z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f';
+    const k = await KeyPair.fromFingerprint({ fingerprint });
+    const k1 = await k.export({ type: 'JsonWebKey2020' });
+    expect(k1).toEqual({
+      id:
+        'did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f#z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-521',
+        x:
+          'AQgyFy6EwH3_u_KXPw8aTXTY7WSVytmbuJeFpq4U6LipxtSmBJe_jjRzms9qubnwm_fGoHMQlvQ1vzS2YLusR2V0',
+        y:
+          'Ab06MCcgoG7dM2I-VppdLV1k3lDoeHMvyYqHVfP05Ep2O7Zu0Qwd6IVzfZi9K0KMDud22wdnGUpUtFukZo0EeO15',
+      },
+    });
+  });
+
+  it('P-384', async () => {
+    const fingerprint =
+      'z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9';
+    const k = await KeyPair.fromFingerprint({ fingerprint });
+    const k1 = await k.export({ type: 'JsonWebKey2020' });
+    expect(k1).toEqual({
+      id:
+        'did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+      type: 'JsonWebKey2020',
+      controller:
+        'did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-384',
+        x: 'lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc',
+        y: 'y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv',
+      },
+    });
+  });
+
+  it('P-256', async () => {
+    const fingerprint = 'zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv';
+    const k = await KeyPair.fromFingerprint({ fingerprint });
+    const k1 = await k.export({ type: 'JsonWebKey2020' });
+    expect(k1).toEqual({
+      id:
+        'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+      type: 'JsonWebKey2020',
+      controller: 'did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-256',
+        x: 'igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns',
+        y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
+      },
+    });
+  });
+});

--- a/packages/web-crypto-key-pair/src/compression/constants.ts
+++ b/packages/web-crypto-key-pair/src/compression/constants.ts
@@ -1,0 +1,34 @@
+import bigInt from 'big-integer';
+
+export const getConstantsForCurve = (curve: string) => {
+  let two, prime, b, pIdent;
+
+  if (curve === 'P-256') {
+    two = new bigInt(2);
+    prime = two
+      .pow(256)
+      .subtract(two.pow(224))
+      .add(two.pow(192))
+      .add(two.pow(96))
+      .subtract(1);
+    b = new bigInt(
+      '41058363725152142129326129780047268409114441015993725554835256314039467401291'
+    );
+    pIdent = prime.add(1).divide(4);
+  }
+
+  if (curve === 'P-384') {
+    two = new bigInt(2);
+    prime = two
+      .pow(384)
+      .subtract(two.pow(128))
+      .subtract(two.pow(96))
+      .add(two.pow(32))
+      .subtract(1);
+    b = new bigInt(
+      '27580193559959705877849011840389048093056905856361568521428707301988689241309860865136260764883745107765439761230575'
+    );
+    pIdent = prime.add(1).divide(4);
+  }
+  return { prime, b, pIdent };
+};

--- a/packages/web-crypto-key-pair/src/compression/constants.ts
+++ b/packages/web-crypto-key-pair/src/compression/constants.ts
@@ -11,10 +11,13 @@ export const getConstantsForCurve = (curve: string) => {
       .add(two.pow(192))
       .add(two.pow(96))
       .subtract(1);
-    b = new bigInt(
-      '41058363725152142129326129780047268409114441015993725554835256314039467401291'
-    );
+
     pIdent = prime.add(1).divide(4);
+
+    b = new bigInt(
+      '5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b',
+      16
+    );
   }
 
   if (curve === 'P-384') {
@@ -25,8 +28,20 @@ export const getConstantsForCurve = (curve: string) => {
       .subtract(two.pow(96))
       .add(two.pow(32))
       .subtract(1);
+
+    pIdent = prime.add(1).divide(4);
     b = new bigInt(
-      '27580193559959705877849011840389048093056905856361568521428707301988689241309860865136260764883745107765439761230575'
+      'b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef',
+      16
+    );
+  }
+
+  if (curve === 'P-521') {
+    two = new bigInt(2);
+    prime = two.pow(521).subtract(1);
+    b = new bigInt(
+      '00000051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00',
+      16
     );
     pIdent = prime.add(1).divide(4);
   }

--- a/packages/web-crypto-key-pair/src/compression/ec-compression.ts
+++ b/packages/web-crypto-key-pair/src/compression/ec-compression.ts
@@ -41,6 +41,7 @@ const curveToPointLength: any = {
 export const expand = (publicKey: Uint8Array, curve: string): Uint8Array => {
   const publicKeyComponent = Buffer.from(publicKey).toString('hex');
   const { prime, b, pIdent } = getConstantsForCurve(curve);
+  // eslint-disable-next-line
   var signY: any = (new Number(publicKeyComponent[1]) as any) - 2;
   var x = new bigInt(publicKeyComponent.substring(2), 16);
   // y^2 = x^3 - 3x + b

--- a/packages/web-crypto-key-pair/src/compression/ec-compression.ts
+++ b/packages/web-crypto-key-pair/src/compression/ec-compression.ts
@@ -1,0 +1,62 @@
+import bigInt from 'big-integer';
+import { getConstantsForCurve } from './constants';
+// see https://stackoverflow.com/questions/17171542/algorithm-for-elliptic-curve-point-compression
+// https://github.com/w3c-ccg/did-method-key/pull/36
+/**
+ * Point compress elliptic curve key
+ * @param {Uint8Array} x component
+ * @param {Uint8Array} y component
+ * @return {Uint8Array} Compressed representation
+ */
+function compressECPoint(x: any, y: any) {
+  const out = new Uint8Array(x.length + 1);
+  out[0] = 2 + (y[y.length - 1] & 1);
+  out.set(x, 1);
+  return out;
+}
+
+function pad_with_zeroes(number: any, length: any) {
+  var retval = '' + number;
+  while (retval.length < length) {
+    retval = '0' + retval;
+  }
+  return retval;
+}
+
+export const compress = (publicKey: Uint8Array): Uint8Array => {
+  const publicKeyHex = Buffer.from(publicKey).toString('hex');
+  const xHex = publicKeyHex.slice(0, publicKeyHex.length / 2);
+  const yHex = publicKeyHex.slice(publicKeyHex.length / 2, publicKeyHex.length);
+  const xOctet = Uint8Array.from(Buffer.from(xHex, 'hex'));
+  const yOctet = Uint8Array.from(Buffer.from(yHex, 'hex'));
+  return compressECPoint(xOctet, yOctet);
+};
+
+const curveToPointLength: any = {
+  'P-256': 64,
+  'P-384': 96,
+};
+
+export const expand = (publicKey: Uint8Array, curve: string): Uint8Array => {
+  const publicKeyComponent = Buffer.from(publicKey).toString('hex');
+  const { prime, b, pIdent } = getConstantsForCurve(curve);
+  var signY: any = (new Number(publicKeyComponent[1]) as any) - 2;
+  var x = new bigInt(publicKeyComponent.substring(2), 16);
+  // y^2 = x^3 - 3x + b
+  var y = x
+    .pow(3)
+    .subtract(x.multiply(3))
+    .add(b)
+    .modPow(pIdent, prime);
+  // If the parity doesn't match it's the *other* root
+  if (y.mod(2).toJSNumber() !== signY) {
+    // y = prime - y
+    y = prime.subtract(y);
+  }
+
+  return Buffer.from(
+    pad_with_zeroes(x.toString(16), curveToPointLength[curve]) +
+      pad_with_zeroes(y.toString(16), curveToPointLength[curve]),
+    'hex'
+  );
+};

--- a/packages/web-crypto-key-pair/src/compression/ec-compression.ts
+++ b/packages/web-crypto-key-pair/src/compression/ec-compression.ts
@@ -35,6 +35,7 @@ export const compress = (publicKey: Uint8Array): Uint8Array => {
 const curveToPointLength: any = {
   'P-256': 64,
   'P-384': 96,
+  'P-521': 132,
 };
 
 export const expand = (publicKey: Uint8Array, curve: string): Uint8Array => {
@@ -43,11 +44,14 @@ export const expand = (publicKey: Uint8Array, curve: string): Uint8Array => {
   var signY: any = (new Number(publicKeyComponent[1]) as any) - 2;
   var x = new bigInt(publicKeyComponent.substring(2), 16);
   // y^2 = x^3 - 3x + b
-  var y = x
+  let y;
+
+  y = x
     .pow(3)
     .subtract(x.multiply(3))
     .add(b)
     .modPow(pIdent, prime);
+
   // If the parity doesn't match it's the *other* root
   if (y.mod(2).toJSNumber() !== signY) {
     // y = prime - y

--- a/packages/web-crypto-key-pair/src/exportAs.ts
+++ b/packages/web-crypto-key-pair/src/exportAs.ts
@@ -1,0 +1,108 @@
+import { base58 } from './encoding';
+import * as key from './key';
+import { JsonWebKey2020, P384Key2021, P256Key2021, P521Key2021 } from './types';
+import { compress } from './compression/ec-compression';
+
+export const toJsonWebKey2020 = async (
+  id: string,
+  controller: string,
+  publicKey: CryptoKey,
+  privateKey?: CryptoKey
+) => {
+  const kp: JsonWebKey2020 = {
+    id: id,
+    type: 'JsonWebKey2020',
+    controller: controller,
+    publicKeyJwk: await key.getJwkFromCryptoKey(publicKey),
+  };
+  if (privateKey) {
+    try {
+      kp.privateKeyJwk = await key.getJwkFromCryptoKey(privateKey);
+    } catch (e) {
+      throw new Error('Cannot export private key');
+    }
+  }
+  return kp;
+};
+
+const conventionExportHelper = async (
+  id: string,
+  type: string,
+  controller: string,
+  publicKey: any,
+  privateKey?: any
+) => {
+  const publicKeyJwk: any = await key.getJwkFromCryptoKey(publicKey);
+  const privateKeyJwk: any = privateKey
+    ? await key.getJwkFromCryptoKey(privateKey)
+    : undefined;
+  const kp: any = {
+    id,
+    type,
+    controller: controller,
+    publicKeyBase58: base58.encode(
+      compress(
+        Buffer.concat([
+          Buffer.from(publicKeyJwk.x, 'base64'),
+          Buffer.from(publicKeyJwk.y, 'base64'),
+        ])
+      )
+    ),
+  };
+  if (privateKeyJwk) {
+    kp.privateKeyBase58 = base58.encode(Buffer.from(privateKeyJwk.d, 'base64'));
+  }
+  return kp;
+};
+
+export const toP521Key2021 = async (
+  id: string,
+  controller: string,
+  publicKey: CryptoKey,
+  privateKey?: CryptoKey
+) => {
+  return conventionExportHelper(
+    id,
+    'P521Key2021',
+    controller,
+    publicKey,
+    privateKey
+  ) as Promise<P521Key2021>;
+};
+
+export const toP384Key2021 = async (
+  id: string,
+  controller: string,
+  publicKey: CryptoKey,
+  privateKey?: CryptoKey
+) => {
+  return conventionExportHelper(
+    id,
+    'P384Key2021',
+    controller,
+    publicKey,
+    privateKey
+  ) as Promise<P384Key2021>;
+};
+
+export const toP256Key2021 = async (
+  id: string,
+  controller: string,
+  publicKey: CryptoKey,
+  privateKey?: CryptoKey
+) => {
+  return conventionExportHelper(
+    id,
+    'P256Key2021',
+    controller,
+    publicKey,
+    privateKey
+  ) as Promise<P256Key2021>;
+};
+
+export const exportableTypes = {
+  JsonWebKey2020: toJsonWebKey2020,
+  P521Key2021: toP521Key2021,
+  P384Key2021: toP384Key2021,
+  P256Key2021: toP256Key2021,
+};

--- a/packages/web-crypto-key-pair/src/key/identifiers.test.ts
+++ b/packages/web-crypto-key-pair/src/key/identifiers.test.ts
@@ -8,8 +8,7 @@ it('p-256', async () => {
     y: 'efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM',
   };
   const calc = await getMulticodec(jwk);
-  const id =
-    'zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve';
+  const id = 'z5bDBRqwwHdvUZ7bd8v8NVbj9VzSitbaS2EePrn3PwBr8nR';
   expect(calc).toBe(id);
 });
 
@@ -21,8 +20,7 @@ it('p-256 2', async () => {
     y: 'hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU',
   };
   const calc = await getMulticodec(jwk);
-  const id =
-    'zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z';
+  const id = 'z5bDBGCcz7d4ueXQqjNauwY8VjE3mkGaEfvTVxRXgQsChxg';
   expect(calc).toBe(id);
 });
 
@@ -35,7 +33,7 @@ it('p-384', async () => {
   };
   const calc = await getMulticodec(jwk);
   const id =
-    'zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU';
+    'z3WFpGi5KxG376emVsW1yELgwp7zAYHNJUnr9qL13fE4xiwvTSqfKPP3KiMh6boCyf3j1';
   expect(calc).toBe(id);
 });
 
@@ -50,6 +48,6 @@ it('p-521', async () => {
   };
   const calc = await getMulticodec(jwk);
   const id =
-    'zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK';
+    'zL2wxdRRkLgCFfATzuBHzzxkRuHZFKhsSEWHfVWkftHunRdDURFVBGKacPiXykrgmNKSfKo4ynjG3Sr7PRUGfCLaVgu8F';
   expect(calc).toBe(id);
 });

--- a/packages/web-crypto-key-pair/src/types/P256Key2021.ts
+++ b/packages/web-crypto-key-pair/src/types/P256Key2021.ts
@@ -1,0 +1,7 @@
+export interface P256Key2021 {
+  id: string;
+  type: 'P256Key2021';
+  controller: string;
+  publicKeyBase58: any;
+  privateKeyBase58?: any;
+}

--- a/packages/web-crypto-key-pair/src/types/P384Key2021.ts
+++ b/packages/web-crypto-key-pair/src/types/P384Key2021.ts
@@ -1,0 +1,7 @@
+export interface P384Key2021 {
+  id: string;
+  type: 'P384Key2021';
+  controller: string;
+  publicKeyBase58: any;
+  privateKeyBase58?: any;
+}

--- a/packages/web-crypto-key-pair/src/types/P521Key2021.ts
+++ b/packages/web-crypto-key-pair/src/types/P521Key2021.ts
@@ -1,0 +1,7 @@
+export interface P521Key2021 {
+  id: string;
+  type: 'P521Key2021';
+  controller: string;
+  publicKeyBase58: any;
+  privateKeyBase58?: any;
+}

--- a/packages/web-crypto-key-pair/src/types/index.ts
+++ b/packages/web-crypto-key-pair/src/types/index.ts
@@ -1,5 +1,9 @@
-export * from './JsonWebKey2020';
 export * from './Signer';
 export * from './Verifier';
 export * from './GenerateKeyOpts';
 export * from './KeyPairOptions';
+
+export * from './JsonWebKey2020';
+export * from './P256Key2021';
+export * from './P384Key2021';
+export * from './P521Key2021';

--- a/packages/web-crypto-key-pair/src/typings.d.ts
+++ b/packages/web-crypto-key-pair/src/typings.d.ts
@@ -1,3 +1,4 @@
 declare module 'canonicalize';
 declare module 'bs58';
 declare module 'base58';
+declare module 'big-integer';


### PR DESCRIPTION
This PR adds EC compression utils that will be needed for web crypto key pairs to generate the proper multibase fingerprints for did:key, and also, export support for multikey formats described here: https://ns.did.ai/suites/multikey-2021/