### PR TITLE
pointing to db release option update, vp test

### DIFF
--- a/packages/linked-data-proof/src/ProofSet.ts
+++ b/packages/linked-data-proof/src/ProofSet.ts
@@ -187,7 +187,9 @@ export class ProofSet {
       purpose,
       documentLoader,
       expansionMap,
-      compactProof = false // digital bazaar doesn't have this option
+      // digital bazaar doesn't have this option as of version 8.0.0
+      // https://github.com/digitalbazaar/jsonld-signatures/blob/9a665c5b712ca997b9ca8205de11fb6f6ae15fe0/CHANGELOG.md#removed
+      compactProof = false
     }: any = {}
   ) => {
     if (!suite) {

--- a/packages/vc.js/package.json
+++ b/packages/vc.js/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
+    "pretest": "node scripts/digital-bazaar.generate-fixture.js",
     "test": "tsdx test",
     "test:jose": "node ./src/vc-jwt/__tests__/EdDSA.jose/EdDSA.jose.js",
     "lint": "tsdx lint src --fix",

--- a/packages/vc.js/scripts/digital-bazaar.generate-fixture.js
+++ b/packages/vc.js/scripts/digital-bazaar.generate-fixture.js
@@ -39,4 +39,37 @@ const credential = require("../src/__fixtures__/credentials/case-1.json");
   } else {
     throw new Error("Expected verifiable credential for case-1.json to verify");
   }
+  const presentation = vc.createPresentation({
+    verifiableCredential,
+    holder: credential.issuer,
+  });
+  const challenge = "fcc8b78e-ecca-426a-a69f-8e7c927b845f";
+  const domain = "org_123";
+  const verifiablePresentation = await vc.signPresentation({
+    presentation,
+    suite,
+    challenge,
+    domain,
+    documentLoader,
+  });
+  const result2 = await vc.verify({
+    presentation: verifiablePresentation,
+    challenge,
+    domain,
+    suite: new Ed25519Signature2018({ key: keyPair }),
+    documentLoader,
+  });
+  if (result2.verified) {
+    fs.writeFileSync(
+      path.resolve(
+        __dirname,
+        `../src/__fixtures__/verifiable-presentations/digital-bazaar/case-1.json`
+      ),
+      JSON.stringify(verifiablePresentation, null, 2)
+    );
+  } else {
+    throw new Error(
+      "Expected verifiable presentation for case-1.json to verify"
+    );
+  }
 })();

--- a/packages/vc.js/scripts/documentLoader.js
+++ b/packages/vc.js/scripts/documentLoader.js
@@ -1,12 +1,12 @@
 const dids = {
-  "did:key:z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk": require("../src/__fixtures__/dids/did-document.json"),
+  "did:key:z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk": require("../src/__fixtures__/dids/did-0.json"),
 };
 const contexts = {
-  "https://www.w3.org/2018/credentials/v1": require("../src/__fixtures__/contexts/credential-v1.json"),
+  "https://www.w3.org/2018/credentials/v1": require("../src/__fixtures__/contexts/cred-v1.json"),
   "https://w3id.org/traceability/v1": require("../src/__fixtures__/contexts/trace-v1.json"),
   "https://www.w3.org/ns/did/v1": require("../src/__fixtures__/contexts/did-v1.json"),
-  "https://w3id.org/security/suites/ed25519-2018/v1": require("../src/__fixtures__/contexts/ed25519-2018-v1.json"),
-  "https://w3id.org/security/suites/x25519-2019/v1": require("../src/__fixtures__/contexts/x25519-2019-v1.json")
+  "https://w3id.org/security/suites/ed25519-2018/v1": require("../src/__fixtures__/contexts/ed25519-v1.json"),
+  "https://w3id.org/security/suites/x25519-2019/v1": require("../src/__fixtures__/contexts/x25519-v1.json"),
 };
 
 const documentLoader = (iri) => {

--- a/packages/vc.js/src/__fixtures__/verifiable-presentations/digital-bazaar/case-1.json
+++ b/packages/vc.js/src/__fixtures__/verifiable-presentations/digital-bazaar/case-1.json
@@ -1,0 +1,192 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": [
+    "VerifiablePresentation"
+  ],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/traceability/v1"
+      ],
+      "id": "http://localhost:8080/credentials/61858f5a-682a-4857-b759-f3487bae0658",
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "type": [
+        "VerifiableCredential",
+        "MillTestReportCertificate"
+      ],
+      "relatedLink": [
+        {
+          "type": "LinkRole",
+          "target": "http://localhost:8080/templates/1a0d2c30-02a0-44cf-b1dc-9fe32652e90d",
+          "linkRelationship": "template",
+          "name": "Template"
+        },
+        {
+          "type": "LinkRole",
+          "target": "http://localhost:8080/batches/a76e12e2-b495-4a03-a32a-5952d14a9798",
+          "linkRelationship": "batch",
+          "name": "Batch"
+        }
+      ],
+      "issuer": "did:key:z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk",
+      "credentialSubject": {
+        "type": [
+          "MillTestReport"
+        ],
+        "manufacturer": {
+          "type": [
+            "Organization"
+          ],
+          "name": "Langworth, McGlynn and Koch",
+          "description": "Exclusive motivating concept",
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "streetAddress": "67663 Roob Highway",
+            "addressLocality": "O'Connellmouth",
+            "addressRegion": "New York",
+            "postalCode": "56036",
+            "addressCountry": "Philippines"
+          },
+          "email": "Eva_Macejkovic@example.net",
+          "phoneNumber": "555-438-8521",
+          "faxNumber": "555-948-7194"
+        },
+        "product": {
+          "type": [
+            "SteelProduct"
+          ],
+          "heatNumber": "4732",
+          "specification": "ASTM-91357",
+          "grade": "4122",
+          "originalCountryOfMeltAndPour": "Madagascar",
+          "inspection": {
+            "type": [
+              "InspectionReport"
+            ],
+            "observation": [
+              {
+                "type": [
+                  "Observation"
+                ],
+                "property": {
+                  "type": [
+                    "ChemicalProperty"
+                  ],
+                  "name": "Actinium"
+                },
+                "measurement": {
+                  "type": [
+                    "MeasuredValue"
+                  ],
+                  "value": "62.813",
+                  "unitCode": "P1"
+                }
+              },
+              {
+                "type": [
+                  "Observation"
+                ],
+                "property": {
+                  "type": [
+                    "MechanicalProperty"
+                  ],
+                  "identifier": "ISO 1352",
+                  "name": "Torque-controlled fatigue testing",
+                  "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+                },
+                "measurement": {
+                  "type": [
+                    "MeasuredValue"
+                  ],
+                  "value": "00.00",
+                  "unitCode": "UNKNOWN"
+                }
+              },
+              {
+                "type": [
+                  "Observation"
+                ],
+                "property": {
+                  "type": [
+                    "ChemicalProperty"
+                  ],
+                  "name": "Oxygen"
+                },
+                "measurement": {
+                  "type": [
+                    "MeasuredValue"
+                  ],
+                  "value": "37.187",
+                  "unitCode": "P1"
+                }
+              }
+            ]
+          }
+        },
+        "purchase": {
+          "type": [
+            "Purchase"
+          ],
+          "customer": {
+            "type": [
+              "Person"
+            ],
+            "email": "Savannah_Homenick@example.com",
+            "phoneNumber": "555-536-5801"
+          }
+        },
+        "shipment": {
+          "type": [
+            "ParcelDelivery"
+          ],
+          "deliveryAddress": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Cassin, Kautzer and Bauch",
+            "streetAddress": "2723 Alana Park",
+            "addressLocality": "South Millie",
+            "addressRegion": "Maryland",
+            "postalCode": "58776",
+            "addressCountry": "Cote d'Ivoire"
+          },
+          "originAddress": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Conn and Sons",
+            "streetAddress": "9424 Alexa Locks",
+            "addressLocality": "West Josefina",
+            "addressRegion": "New Hampshire",
+            "postalCode": "99598",
+            "addressCountry": "Gabon"
+          },
+          "deliveryMethod": "Truck transport",
+          "trackingNumber": "547132175583"
+        }
+      },
+      "proof": {
+        "type": "Ed25519Signature2018",
+        "created": "2010-01-01T19:23:24Z",
+        "verificationMethod": "did:key:z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk#z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk",
+        "proofPurpose": "assertionMethod",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..M5DWqdH00x4l_b-I9UnG-3vFpizdiploi77tlUe2-iw8Eg5mRMpVUWEwZZ7duNIOk4waXXvonCSJz2kMgjkZDQ"
+      }
+    }
+  ],
+  "holder": "did:key:z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk",
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2010-01-01T19:23:24Z",
+    "verificationMethod": "did:key:z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk#z6MktWjP95fMqCMrfNULcdszFeTVUCE1zcgz3Hv5bVAisHgk",
+    "proofPurpose": "authentication",
+    "challenge": "fcc8b78e-ecca-426a-a69f-8e7c927b845f",
+    "domain": "org_123",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..FscdrQixKzE4XRsZg1rSn4ylvetD3VlI8j7egrcka84k4GtxUZ_idp66nERKcavfiTRtjGpsSY7smynZVgu_Cg"
+  }
+}

--- a/packages/vc.js/src/__tests__/basic.test.ts
+++ b/packages/vc.js/src/__tests__/basic.test.ts
@@ -8,10 +8,14 @@ import rawKeyJson from "../__fixtures__/keys/key.json";
 import credential from "../__fixtures__/credentials/case-1.json";
 import documentLoader from "../__fixtures__/documentLoader";
 import expectedVerifiableCredential from "../__fixtures__/verifiable-credentials/digital-bazaar/case-1.json";
+import expectedVerifiablePresentation from "../__fixtures__/verifiable-presentations/digital-bazaar/case-1.json";
 
+const challenge = "fcc8b78e-ecca-426a-a69f-8e7c927b845f";
+const domain = "org_123";
 let keyPair: Ed25519VerificationKey2018;
 let suite: Ed25519Signature2018;
 let verifiableCredential: any;
+let verifiablePresentation: any;
 describe("create and verify verifiable credentials", () => {
   it("import key", async () => {
     keyPair = await Ed25519VerificationKey2018.from(rawKeyJson);
@@ -36,7 +40,7 @@ describe("create and verify verifiable credentials", () => {
     verifiableCredential = result.items[0];
   });
 
-  it("should match fixture", async () => {
+  it("verifiable credential should match fixture", async () => {
     expect(expectedVerifiableCredential).toEqual(verifiableCredential);
   });
 
@@ -48,6 +52,40 @@ describe("create and verify verifiable credentials", () => {
       suite: [new Ed25519Signature2018()]
     });
     expect(verifiableCredential.proof["@context"]).toBeFalsy();
+    expect(result.verified).toBeTruthy();
+  });
+
+  it("create verifiable presentation", async () => {
+    const presentation = {
+      "@context": ["https://www.w3.org/2018/credentials/v1"],
+      type: ["VerifiablePresentation"],
+      verifiableCredential: [verifiableCredential],
+      holder: credential.issuer
+    };
+
+    const result = await vcjs.verifiable.presentation.create({
+      presentation,
+      format: ["vp"],
+      documentLoader: documentLoader,
+      challenge,
+      domain,
+      suite
+    });
+    verifiablePresentation = result.items[0];
+  });
+  it("verifiable presentation should match fixure", async () => {
+    expect(expectedVerifiablePresentation).toEqual(verifiablePresentation);
+  });
+  it("verify verifiable presentation", async () => {
+    const result = await vcjs.verifiable.presentation.verify({
+      presentation: verifiablePresentation,
+      format: ["vp"],
+      documentLoader: documentLoader,
+      challenge,
+      domain,
+      suite: new Ed25519Signature2018()
+    });
+    expect(verifiablePresentation.proof["@context"]).toBeFalsy();
     expect(result.verified).toBeTruthy();
   });
 });


### PR DESCRIPTION
The changes I did with most recent PR don’t change the behavior of this last PR, just adding a test around presentations (presentations calls credential verify which had been fixed already), and referencing digital bazaar release update on supported options.