### PR TITLE
vc.js credential verify tests option compactProof true failure

### DIFF
--- a/packages/vc.js/src/__tests__/verify-options.test.ts
+++ b/packages/vc.js/src/__tests__/verify-options.test.ts
@@ -1,6 +1,6 @@
 import {
   Ed25519Signature2018,
-  Ed25519VerificationKey2018
+  Ed25519VerificationKey2018,
 } from "@transmute/ed25519-signature-2018";
 
 import * as vcjs from "..";
@@ -12,6 +12,12 @@ let keyPair: Ed25519VerificationKey2018;
 let suite: Ed25519Signature2018;
 let verifiableCredential: any;
 
+// We found an edge case where pre-processing broke the signature.
+// Here are some tests that show this.
+// These tests won't ever pass (failure is expected) and the failure is related to pre-processing the credential.
+// Eventually we should remove the compactProof option so that these tests are no longer needed.
+// https://github.com/transmute-industries/verifiable-data/issues/112#issuecomment-963292075
+// FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
 describe("create and verify verifiable credentials", () => {
   it("import key", async () => {
     keyPair = await Ed25519VerificationKey2018.from(rawKeyJson);
@@ -21,7 +27,7 @@ describe("create and verify verifiable credentials", () => {
   it("define suite", async () => {
     suite = new Ed25519Signature2018({
       key: keyPair,
-      date: credential.issuanceDate
+      date: credential.issuanceDate,
     });
     expect(suite.verificationMethod).toBe(rawKeyJson.id);
   });
@@ -31,7 +37,7 @@ describe("create and verify verifiable credentials", () => {
       format: ["vc"],
       credential,
       suite,
-      documentLoader
+      documentLoader,
     });
     verifiableCredential = result.items[0];
   });
@@ -43,10 +49,12 @@ describe("create and verify verifiable credentials", () => {
       documentLoader,
       suite: [new Ed25519Signature2018()],
       expansionMap: true,
-      compactProof: true
+      compactProof: true,
     });
     // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
-    expect(result.error.errors[0].message).toBe('The property "grade" in the input was not defined in the context.');
+    expect(result.error.errors[0].message).toBe(
+      'The property "grade" in the input was not defined in the context.'
+    );
   });
 
   it("expansionMap undefined / compactProof true - Fails to verify verifiable credential", async () => {
@@ -55,10 +63,12 @@ describe("create and verify verifiable credentials", () => {
       format: ["vc"],
       documentLoader,
       suite: [new Ed25519Signature2018()],
-      compactProof: true
+      compactProof: true,
     });
     // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
-    expect(result.error.errors[0].message).toBe('The property "grade" in the input was not defined in the context.');
+    expect(result.error.errors[0].message).toBe(
+      'The property "grade" in the input was not defined in the context.'
+    );
   });
 
   it("expansionMap false / compactProof true - Fails to verify verifiable credential", async () => {
@@ -68,9 +78,8 @@ describe("create and verify verifiable credentials", () => {
       documentLoader,
       suite: [new Ed25519Signature2018()],
       expansionMap: false,
-      compactProof: true
+      compactProof: true,
     });
-    // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
-    expect(result.error.errors[0].message).toBe('Invalid signature.');
+    expect(result.error.errors[0].message).toBe("Invalid signature.");
   });
 });

--- a/packages/vc.js/src/__tests__/verify-options.test.ts
+++ b/packages/vc.js/src/__tests__/verify-options.test.ts
@@ -51,7 +51,6 @@ describe("create and verify verifiable credentials", () => {
       expansionMap: true,
       compactProof: true,
     });
-    // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
     expect(result.error.errors[0].message).toBe(
       'The property "grade" in the input was not defined in the context.'
     );
@@ -65,7 +64,6 @@ describe("create and verify verifiable credentials", () => {
       suite: [new Ed25519Signature2018()],
       compactProof: true,
     });
-    // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
     expect(result.error.errors[0].message).toBe(
       'The property "grade" in the input was not defined in the context.'
     );

--- a/packages/vc.js/src/__tests__/verify-options.test.ts
+++ b/packages/vc.js/src/__tests__/verify-options.test.ts
@@ -1,0 +1,76 @@
+import {
+  Ed25519Signature2018,
+  Ed25519VerificationKey2018
+} from "@transmute/ed25519-signature-2018";
+
+import * as vcjs from "..";
+import rawKeyJson from "../__fixtures__/keys/key.json";
+import credential from "../__fixtures__/credentials/case-1.json";
+import documentLoader from "../__fixtures__/documentLoader";
+
+let keyPair: Ed25519VerificationKey2018;
+let suite: Ed25519Signature2018;
+let verifiableCredential: any;
+
+describe("create and verify verifiable credentials", () => {
+  it("import key", async () => {
+    keyPair = await Ed25519VerificationKey2018.from(rawKeyJson);
+    expect(keyPair.controller).toBe(rawKeyJson.controller);
+  });
+
+  it("define suite", async () => {
+    suite = new Ed25519Signature2018({
+      key: keyPair,
+      date: credential.issuanceDate
+    });
+    expect(suite.verificationMethod).toBe(rawKeyJson.id);
+  });
+
+  it("create verifiable credential", async () => {
+    const result = await vcjs.verifiable.credential.create({
+      format: ["vc"],
+      credential,
+      suite,
+      documentLoader
+    });
+    verifiableCredential = result.items[0];
+  });
+
+  it("expansionMap true / compactProof true - Fails to verify verifiable credential", async () => {
+    const result = await vcjs.verifiable.credential.verify({
+      credential: verifiableCredential,
+      format: ["vc"],
+      documentLoader,
+      suite: [new Ed25519Signature2018()],
+      expansionMap: true,
+      compactProof: true
+    });
+    // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
+    expect(result.error.errors[0].message).toBe('The property "grade" in the input was not defined in the context.');
+  });
+
+  it("expansionMap undefined / compactProof true - Fails to verify verifiable credential", async () => {
+    const result = await vcjs.verifiable.credential.verify({
+      credential: verifiableCredential,
+      format: ["vc"],
+      documentLoader,
+      suite: [new Ed25519Signature2018()],
+      compactProof: true
+    });
+    // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
+    expect(result.error.errors[0].message).toBe('The property "grade" in the input was not defined in the context.');
+  });
+
+  it("expansionMap false / compactProof true - Fails to verify verifiable credential", async () => {
+    const result = await vcjs.verifiable.credential.verify({
+      credential: verifiableCredential,
+      format: ["vc"],
+      documentLoader,
+      suite: [new Ed25519Signature2018()],
+      expansionMap: false,
+      compactProof: true
+    });
+    // FIXME: https://github.com/transmute-industries/verifiable-data/issues/112
+    expect(result.error.errors[0].message).toBe('Invalid signature.');
+  });
+});


### PR DESCRIPTION
Demonstrates that when using compactProof set to true it results in two different failures on attempting to verify a MTR VC.
This PR relates to https://github.com/transmute-industries/verifiable-data/issues/112