### PR TITLE
fix: handle ports in did:web DIDs

### DIFF
--- a/packages/did-web/src/convertDidToEndpoint.ts
+++ b/packages/did-web/src/convertDidToEndpoint.ts
@@ -1,6 +1,6 @@
 export const convertDidToEndpoint = (did: string) => {
   const regex = new RegExp(
-    `did:web:(?<host>[a-zA-Z0-9/.\\-_]+)(:*)(?<port>[0-9]+)*(:*)(?<path>[a-zA-Z0-9/.:\\-_]*)`
+    `did:web:(?<host>[a-zA-Z0-9/.\\-_]+)(?:%3A(?<port>[0-9]+))?(:*)(?<path>[a-zA-Z0-9/.:\\-_]*)`
   );
   const match: any = did.match(regex);
 

--- a/packages/did-web/src/integration.test.ts
+++ b/packages/did-web/src/integration.test.ts
@@ -6,3 +6,9 @@ it("basic", () => {
   const did = convertEndpointToDid(endpoint);
   expect(did).toBe("did:web:api.did.actor:api");
 });
+
+it("with port", () => {
+  const endpoint = convertDidToEndpoint("did:web:api.did.actor%3A8080:api");
+  const did = convertEndpointToDid(endpoint);
+  expect(did).toBe("did:web:api.did.actor%3A8080:api");
+})


### PR DESCRIPTION
This PR fixes the regex in `convertDidToEnpoint()` so that it handles url-encoded `host:port` values.

Fixes #205 