### PR TITLE
fix: vc-jwt handle credential subject objects w/o id

### DIFF
--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/contexts.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/contexts.ts
@@ -1,0 +1,15 @@
+import cre from "@transmute/credentials-context";
+import sec from "@transmute/security-context";
+import did from "@transmute/did-context";
+
+export const contexts: any = {
+  [sec.constants.JSON_WEB_SIGNATURE_2020_V1_URL]: sec.contexts.get(
+    sec.constants.JSON_WEB_SIGNATURE_2020_V1_URL
+  ),
+  [cre.constants.CREDENTIALS_CONTEXT_V1_URL]: cre.contexts.get(
+    cre.constants.CREDENTIALS_CONTEXT_V1_URL
+  ),
+  [did.constants.DID_CONTEXT_V1_URL]: did.contexts.get(
+    did.constants.DID_CONTEXT_V1_URL
+  )
+};

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/credential.json
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/credential.json
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    {
+      "@vocab": "http://schema.og/"
+    }
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "https://example.edu/issuers/14",
+  "issuanceDate": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "type": "Product",
+    "offers": [
+      {
+        "name": "Handmade Fresh Hat"
+      }
+    ]
+  }
+}

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/credential2.json
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/credential2.json
@@ -1,0 +1,23 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    {
+      "@vocab": "http://schema.og/"
+    }
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "https://example.edu/issuers/14",
+  "issuanceDate": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "type": "Product",
+    "offers": [
+      {
+        "name": "Handmade Fresh Hat"
+      }
+    ]
+  }
+}

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/documentLoader.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/documentLoader.ts
@@ -1,0 +1,19 @@
+import { contexts } from "./contexts";
+
+const contextResolver = async (iri: string) => {
+  if (contexts[iri]) {
+    return { document: contexts[iri] };
+  }
+  return undefined;
+};
+
+export const documentLoader = async (iri: string) => {
+  const context = await contextResolver(iri);
+  if (context) {
+    return context;
+  }
+
+  const message = "Unsupported iri: " + iri;
+  console.error(message);
+  throw new Error(message);
+};

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/index.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/index.ts
@@ -1,0 +1,10 @@
+import credential from "./credential.json";
+import credential2 from "./credential2.json";
+
+import { documentLoader } from "./documentLoader";
+
+export {
+  credential,
+  credential2,
+  documentLoader,
+};

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/index.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/__fixtures__/index.ts
@@ -3,8 +3,4 @@ import credential2 from "./credential2.json";
 
 import { documentLoader } from "./documentLoader";
 
-export {
-  credential,
-  credential2,
-  documentLoader,
-};
+export { credential, credential2, documentLoader };

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/createVcPayload.test.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/createVcPayload.test.ts
@@ -1,0 +1,22 @@
+import { createVcPayload } from "../../createVcPayload";
+import { credential, credential2, documentLoader } from "./__fixtures__";
+
+describe("createVcPayload", () => {
+  it("should remove sub if credentialSubject is an object that does not have id attribute", async () => {
+    const options = {
+      format: "vc-jwt",
+      documentLoader,
+    };
+    const payload: any = await createVcPayload(credential, options);
+    expect(payload.sub).toBeFalsy();
+  });
+
+  it("should remove sub if credentialSubject is an object that does not have id attribute", async () => {
+    const options = {
+      format: "vc-jwt",
+      documentLoader,
+    };
+    const payload: any = await createVcPayload(credential2, options);
+    expect(payload.sub).toBe(credential2.credentialSubject.id);
+  });
+});

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/createVcPayload.test.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/createVcPayload.test.ts
@@ -11,7 +11,7 @@ describe("createVcPayload", () => {
     expect(payload.sub).toBeFalsy();
   });
 
-  it("should remove sub if credentialSubject is an object that does not have id attribute", async () => {
+  it("sub should be id string if credentialSubject is an object that does have id attribute", async () => {
     const options = {
       format: "vc-jwt",
       documentLoader

--- a/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/createVcPayload.test.ts
+++ b/packages/vc.js/src/vc-jwt/__tests__/createVcPayload/createVcPayload.test.ts
@@ -5,7 +5,7 @@ describe("createVcPayload", () => {
   it("should remove sub if credentialSubject is an object that does not have id attribute", async () => {
     const options = {
       format: "vc-jwt",
-      documentLoader,
+      documentLoader
     };
     const payload: any = await createVcPayload(credential, options);
     expect(payload.sub).toBeFalsy();
@@ -14,7 +14,7 @@ describe("createVcPayload", () => {
   it("should remove sub if credentialSubject is an object that does not have id attribute", async () => {
     const options = {
       format: "vc-jwt",
-      documentLoader,
+      documentLoader
     };
     const payload: any = await createVcPayload(credential2, options);
     expect(payload.sub).toBe(credential2.credentialSubject.id);

--- a/packages/vc.js/src/vc-jwt/createVcPayload.ts
+++ b/packages/vc.js/src/vc-jwt/createVcPayload.ts
@@ -39,7 +39,7 @@ export const createVcPayload = async (
     sub: subject,
     vc: credential,
     jti: credential.id,
-    nbf: moment(credential.issuanceDate).unix(),
+    nbf: moment(credential.issuanceDate).unix()
   };
   if (credential.expirationDate) {
     payload.exp = moment(credential.expirationDate).unix();

--- a/packages/vc.js/src/vc-jwt/createVcPayload.ts
+++ b/packages/vc.js/src/vc-jwt/createVcPayload.ts
@@ -20,15 +20,26 @@ export const createVcPayload = async (
   const issuer = credential.issuer.id
     ? credential.issuer.id
     : credential.issuer;
-  const subject = credential.credentialSubject.id
-    ? credential.credentialSubject.id
-    : credential.credentialSubject;
+  let subject = undefined;
+  if (
+    typeof credential.credentialSubject === "string" ||
+    credential.credentialSubject instanceof String
+  ) {
+    subject = credential.credentialSubject;
+  }
+  if (
+    typeof credential.credentialSubject === "object" &&
+    credential.credentialSubject !== null &&
+    credential.credentialSubject.id
+  ) {
+    subject = credential.credentialSubject.id;
+  }
   const payload: any = {
     iss: issuer,
     sub: subject,
     vc: credential,
     jti: credential.id,
-    nbf: moment(credential.issuanceDate).unix()
+    nbf: moment(credential.issuanceDate).unix(),
   };
   if (credential.expirationDate) {
     payload.exp = moment(credential.expirationDate).unix();


### PR DESCRIPTION
This PR fixes the possibility of having an object for the sub (subject attribute) in the jwt of a vc.